### PR TITLE
Fix rspec deprecations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rake'
 gem 'bson_ext', '~> 1.8'
 
 group(:test) do
-  gem 'rspec'
+  gem 'rspec', '~> 3.4.0'
 end
 
 group(:guard) do

--- a/spec/mongo_atomic_spec.rb
+++ b/spec/mongo_atomic_spec.rb
@@ -18,7 +18,7 @@ describe "Mongo atomic adapter" do
     oid = BSON::ObjectId.new
     adapter.write(oid, {'a' => 'c', 'b' => 'd'})
     adapter.write(oid, {'a' => 'z'})
-    adapter.read(oid).should eq({
+    expect(adapter.read(oid)).to eq({
       'a' => 'z',
       'b' => 'd',
     })

--- a/spec/support/shared_mongo_adapter.rb
+++ b/spec/support/shared_mongo_adapter.rb
@@ -5,29 +5,29 @@ shared_examples_for "a mongo adapter" do
     id = BSON::ObjectId.new
     attributes = {'one' => 'two'}
     adapter.write(id, attributes)
-    client.find_one('_id' => id).should_not be_nil
-    adapter.read(id).should == attributes
+    expect(client.find_one('_id' => id)).not_to be_nil
+    expect(adapter.read(id)).to eq(attributes)
   end
 
   it "allows using ordered hashes as keys" do
     key = BSON::OrderedHash['d', 1, 'n', 1]
     attributes = {'one' => 'two'}
     adapter.write(key, attributes)
-    client.find_one('_id' => key).should_not be_nil
-    adapter.read(key).should == attributes
+    expect(client.find_one('_id' => key)).not_to be_nil
+    expect(adapter.read(key)).to eq(attributes)
   end
 
   it "allows using hashes as keys" do
     key = {:d => 1}
     attributes = {'one' => 'two'}
     adapter.write(key, attributes)
-    client.find_one('_id' => key).should_not be_nil
-    adapter.read(key).should == attributes
+    expect(client.find_one('_id' => key)).not_to be_nil
+    expect(adapter.read(key)).to eq(attributes)
   end
 
   it "stores hashes right in document" do
     adapter.write('foo', 'steak' => 'bacon')
-    client.find_one('_id' => 'foo').should == {'_id' => 'foo', 'steak' => 'bacon'}
+    expect(client.find_one('_id' => 'foo')).to eq({'_id' => 'foo', 'steak' => 'bacon'})
   end
 
   describe "with safe option" do
@@ -43,16 +43,16 @@ shared_examples_for "a mongo adapter" do
 
       it "does not raise operation failure on write if operation succeeds" do
         adapter.write(BSON::ObjectId.new, {'email' => 'john@orderedlist.com'})
-        lambda {
+        expect {
           adapter.write(BSON::ObjectId.new, {'email' => 'steve@orderedlist.com'})
-        }.should_not raise_error(Mongo::OperationFailure)
+        }.not_to raise_error(Mongo::OperationFailure)
       end
 
       it "raises operation failure on write if operation fails" do
         adapter.write(BSON::ObjectId.new, {'email' => 'john@orderedlist.com'})
-        lambda {
+        expect {
           adapter.write(BSON::ObjectId.new, {'email' => 'john@orderedlist.com'})
-        }.should raise_error(Mongo::OperationFailure)
+        }.to raise_error(Mongo::OperationFailure)
       end
     end
 
@@ -68,16 +68,16 @@ shared_examples_for "a mongo adapter" do
 
       it "does not raise operation failure on write if operation succeeds" do
         adapter.write(BSON::ObjectId.new, {'email' => 'john@orderedlist.com'})
-        lambda {
+        expect {
           adapter.write(BSON::ObjectId.new, {'email' => 'steve@orderedlist.com'})
-        }.should_not raise_error(Mongo::OperationFailure)
+        }.not_to raise_error(Mongo::OperationFailure)
       end
 
       it "does not raise operation failure on write if operation fails" do
         adapter.write(BSON::ObjectId.new, {'email' => 'john@orderedlist.com'})
-        lambda {
+        expect {
           adapter.write(BSON::ObjectId.new, {'email' => 'john@orderedlist.com'})
-        }.should_not raise_error(Mongo::OperationFailure)
+        }.not_to raise_error(Mongo::OperationFailure)
       end
     end
   end
@@ -94,21 +94,21 @@ shared_examples_for "a mongo adapter" do
 
     it "does not raise operation failure on write if operation succeeds" do
       adapter.write(BSON::ObjectId.new, {'email' => 'john@orderedlist.com'})
-      lambda {
+      expect {
         adapter.write(BSON::ObjectId.new, {'email' => 'steve@orderedlist.com'})
-      }.should_not raise_error(Mongo::OperationFailure)
+      }.not_to raise_error(Mongo::OperationFailure)
     end
 
     it "raises operation failure on write if operation fails" do
       adapter.write(BSON::ObjectId.new, {'email' => 'john@orderedlist.com'})
-      lambda {
+      expect {
         adapter.write(BSON::ObjectId.new, {'email' => 'john@orderedlist.com'})
-      }.should raise_error(Mongo::OperationFailure)
+      }.to raise_error(Mongo::OperationFailure)
     end
 
     it "allows overriding write concern for write" do
       id = BSON::ObjectId.new
-      client.should_receive(:update).
+      expect(client).to receive(:update).
         with(
           hash_including(:_id),
           kind_of(Hash),
@@ -119,25 +119,25 @@ shared_examples_for "a mongo adapter" do
 
     it "uses write concern for delete" do
       id = BSON::ObjectId.new
-      client.should_receive(:remove).with({:_id => id}, :w => 1)
+      expect(client).to receive(:remove).with({:_id => id}, :w => 1)
       adapter.delete(id)
     end
 
     it "allows overriding write concern for delete" do
       id = BSON::ObjectId.new
-      client.should_receive(:remove).with({:_id => id}, :w => 0)
+      expect(client).to receive(:remove).with({:_id => id}, :w => 0)
       adapter.delete(id, :w => 0)
     end
 
     it "uses write concern for clear" do
       id = BSON::ObjectId.new
-      client.should_receive(:remove).with({}, :w => 1)
+      expect(client).to receive(:remove).with({}, :w => 1)
       adapter.clear
     end
 
     it "allows overriding write concern for clear" do
       id = BSON::ObjectId.new
-      client.should_receive(:remove).with({}, :w => 0)
+      expect(client).to receive(:remove).with({}, :w => 0)
       adapter.clear(:w => 0)
     end
   end

--- a/spec/support/shared_mongo_adapter.rb
+++ b/spec/support/shared_mongo_adapter.rb
@@ -45,7 +45,7 @@ shared_examples_for "a mongo adapter" do
         adapter.write(BSON::ObjectId.new, {'email' => 'john@orderedlist.com'})
         expect {
           adapter.write(BSON::ObjectId.new, {'email' => 'steve@orderedlist.com'})
-        }.not_to raise_error(Mongo::OperationFailure)
+        }.not_to raise_error
       end
 
       it "raises operation failure on write if operation fails" do
@@ -70,14 +70,14 @@ shared_examples_for "a mongo adapter" do
         adapter.write(BSON::ObjectId.new, {'email' => 'john@orderedlist.com'})
         expect {
           adapter.write(BSON::ObjectId.new, {'email' => 'steve@orderedlist.com'})
-        }.not_to raise_error(Mongo::OperationFailure)
+        }.not_to raise_error
       end
 
       it "does not raise operation failure on write if operation fails" do
         adapter.write(BSON::ObjectId.new, {'email' => 'john@orderedlist.com'})
         expect {
           adapter.write(BSON::ObjectId.new, {'email' => 'john@orderedlist.com'})
-        }.not_to raise_error(Mongo::OperationFailure)
+        }.not_to raise_error
       end
     end
   end
@@ -96,7 +96,7 @@ shared_examples_for "a mongo adapter" do
       adapter.write(BSON::ObjectId.new, {'email' => 'john@orderedlist.com'})
       expect {
         adapter.write(BSON::ObjectId.new, {'email' => 'steve@orderedlist.com'})
-      }.not_to raise_error(Mongo::OperationFailure)
+      }.not_to raise_error
     end
 
     it "raises operation failure on write if operation fails" do


### PR DESCRIPTION
This mirrors changes in https://github.com/jnunemaker/adapter/pull/6 and more description is there.

This updates rspec to latest version and syntax and sets the version explicitly so it can match the `adapter` gem.
